### PR TITLE
fix: avoid panic in layout when a section has no page definition

### DIFF
--- a/src/render/layout.rs
+++ b/src/render/layout.rs
@@ -80,10 +80,10 @@ impl<'a> LayoutEngine<'a> {
         let mut pages = Vec::new();
 
         // Get page definition
-        let page_def = section
-            .page_def
-            .as_ref()
-            .expect("Section must have page definition");
+        let page_def = match section.page_def.as_ref() {
+            Some(page_def) => page_def,
+            None => return pages,
+        };
 
         let mut current_page = RenderedPage {
             width: page_def.width,

--- a/tests/layout_missing_page_def_test.rs
+++ b/tests/layout_missing_page_def_test.rs
@@ -1,0 +1,22 @@
+use hwpers::render::layout::LayoutEngine;
+use hwpers::HwpReader;
+use std::path::PathBuf;
+
+/// A section without a PageDef record must not panic during layout.
+/// `styled_document.hwp` (shipped in the repo) parses into a section whose
+/// `page_def` is `None`, which previously triggered a panic in `layout_section`.
+#[test]
+fn test_layout_section_without_page_def_does_not_panic() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("styled_document.hwp");
+    let bytes = std::fs::read(&path).expect("failed to read styled_document.hwp");
+    let doc = HwpReader::from_bytes(&bytes).expect("failed to parse styled_document.hwp");
+
+    assert!(
+        doc.sections().any(|s| s.page_def.is_none()),
+        "expected at least one section without a page definition"
+    );
+
+    let engine = LayoutEngine::new(&doc);
+    let result = engine.calculate_layout();
+    assert!(result.pages.is_empty());
+}


### PR DESCRIPTION
## Problem

`LayoutEngine::calculate_layout()` panics on a parsed document whose section has no `PageDef` record:

```
thread 'main' panicked at src/render/layout.rs:86:14:
Section must have page definition
```

`layout_section` unwraps `section.page_def` with `.expect("Section must have page definition")`. But a page definition is optional in the body-text stream — `PageDef` is only set for the `PageDef` (0x57) record, and `Section::page_def` defaults to `None`. Any valid HWP file that doesn't carry that record crashes every caller of the public layout API.

This is reproducible with the repository's own sample file `styled_document.hwp`, which parses cleanly but has no page definition:

```rust
let bytes = std::fs::read("styled_document.hwp").unwrap();
let doc = HwpReader::from_bytes(&bytes).unwrap(); // OK
LayoutEngine::new(&doc).calculate_layout();        // panics
```

(`converted_output.hwp`, which does carry a `PageDef`, lays out fine — 2 pages.)

## Fix

Skip a section that has no page definition instead of unwrapping, so layout returns whatever it can rather than aborting the process.

## Tests

- New regression test `tests/layout_missing_page_def_test.rs` loads the shipped `styled_document.hwp`, asserts a section has no `page_def`, and checks `calculate_layout()` returns without panicking.
- Verified RED→GREEN: the test panics on the old code and passes on the fix.
- Full suite green: `cargo test --all-features` — 150 tests pass, 0 failures.

Validation commands:
```
cargo test --all-features
cargo test --test layout_missing_page_def_test
```
